### PR TITLE
feat: add MovieController

### DIFF
--- a/library/src/main/java/org/pollub/library/item/controller/MovieController.java
+++ b/library/src/main/java/org/pollub/library/item/controller/MovieController.java
@@ -1,0 +1,76 @@
+package org.pollub.library.item.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.pollub.library.item.model.MovieDisc;
+import org.pollub.library.item.model.dto.MovieCreateDto;
+import org.pollub.library.item.service.IMovieService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/movie")
+@RequiredArgsConstructor
+public class MovieController {
+    private final IMovieService movieService;
+
+    @PostMapping
+    public ResponseEntity<MovieDisc> createMovie(@Valid @RequestBody MovieCreateDto dto) {
+        return ResponseEntity.ok(movieService.createMovie(dto));
+    }
+    @GetMapping("/{id}")
+    public ResponseEntity<MovieDisc> getMovie(@PathVariable Long id) {
+        return ResponseEntity.ok(movieService.findById(id));
+    }
+
+    @GetMapping("/director/{director}")
+    public ResponseEntity<List<MovieDisc>> getMoviesByDirector(@PathVariable String director) {
+        return ResponseEntity.ok(movieService.findByDirector(director));
+    }
+
+    @GetMapping("/genre/{genre}")
+    public ResponseEntity<List<MovieDisc>> getMoviesByGenre(@PathVariable String genre) {
+        return ResponseEntity.ok(movieService.findByGenre(genre));
+    }
+
+    @GetMapping("/fileFormat/{fileFormat}")
+    public ResponseEntity<List<MovieDisc>> getMoviesByFileFormat(@PathVariable String fileFormat) {
+        return ResponseEntity.ok(movieService.findByFileFormat(fileFormat));
+    }
+
+    @GetMapping("/resolution/{resolution}")
+    public ResponseEntity<List<MovieDisc>> getMoviesByResolution(@PathVariable String resolution) {
+        return ResponseEntity.ok(movieService.findByResolution(resolution));
+    }
+
+    @GetMapping("/duration")
+    public ResponseEntity<List<MovieDisc>> getMoviesByDurationBetween(
+            @RequestParam Integer minDuration, @RequestParam Integer maxDuration) {
+        return ResponseEntity.ok(movieService.findByDurationBetween(minDuration, maxDuration));
+    }
+
+    @GetMapping("/titleAndDirector")
+    public ResponseEntity<MovieDisc> getMovieByTitleAndDirector(
+            @RequestParam String title, @RequestParam String director) {
+        Optional<MovieDisc> movie = movieService.findByTitleAndDirector(title, director);
+        return movie.map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<MovieDisc> updateMovie(
+            @PathVariable Long id,
+            @Valid @RequestBody MovieCreateDto dto
+    ) {
+        return ResponseEntity.ok(movieService.updateMovie(id, dto));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<String> deleteMovie(@PathVariable Long id) {
+        movieService.deleteMovie(id);
+        return ResponseEntity.ok("Movie deleted");
+    }
+}

--- a/library/src/main/java/org/pollub/library/item/model/dto/MovieCreateDto.java
+++ b/library/src/main/java/org/pollub/library/item/model/dto/MovieCreateDto.java
@@ -10,6 +10,8 @@ public class MovieCreateDto {
     @NotBlank(message = "Title is required")
     private String title;
 
+    private String description;
+
     @NotBlank(message = "Director is required")
     private String director;
 

--- a/library/src/main/java/org/pollub/library/item/service/IMovieService.java
+++ b/library/src/main/java/org/pollub/library/item/service/IMovieService.java
@@ -4,12 +4,17 @@ import org.pollub.library.item.model.MovieDisc;
 import org.pollub.library.item.model.dto.MovieCreateDto;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface IMovieService {
     MovieDisc createMovie(MovieCreateDto dto);
     MovieDisc findById(Long id);
     List<MovieDisc> findByDirector(String director);
     List<MovieDisc> findByGenre(String genre);
+    List<MovieDisc> findByFileFormat(String fileFormat);
+    List<MovieDisc> findByResolution(String resolution);
+    List<MovieDisc> findByDurationBetween(Integer minDuration, Integer maxDuration);
+    Optional<MovieDisc> findByTitleAndDirector(String title, String director);
     MovieDisc updateMovie(Long id, MovieCreateDto dto);
     void deleteMovie(Long id);
 }

--- a/library/src/main/java/org/pollub/library/item/service/MovieService.java
+++ b/library/src/main/java/org/pollub/library/item/service/MovieService.java
@@ -42,6 +42,26 @@ public class MovieService implements IMovieService{
     }
 
     @Override
+    public List<MovieDisc> findByFileFormat(String fileFormat) {
+        return movieRepository.findByFileFormat(fileFormat);
+    }
+
+    @Override
+    public List<MovieDisc> findByResolution(String resolution) {
+        return movieRepository.findByResolution(resolution);
+    }
+
+    @Override
+    public List<MovieDisc> findByDurationBetween(Integer minDuration, Integer maxDuration) {
+        return movieRepository.findByDurationBetween(minDuration, maxDuration);
+    }
+
+    @Override
+    public Optional<MovieDisc> findByTitleAndDirector(String title, String director) {
+        return movieRepository.findByTitleAndAndDirector(title, director);
+    }
+
+    @Override
     public MovieDisc updateMovie(Long id, MovieCreateDto dto) {
         var movie = findById(id);
         mapMovieFromDto(movie, dto);


### PR DESCRIPTION
# MovieController

This controller handles the HTTP requests for managing `MovieDisc` entities in the system. It provides several endpoints to perform CRUD (Create, Read, Update, Delete) operations and search for movies by various criteria.

## Endpoints

   - **POST** `/api/movie` (Create a new Movie)
   - **GET** `/api/movie/{id}` (Get movie by ID)
   - **GET** `/api/movie/director/{director}` (Get movies by director)
   - **GET** `/api/movie/genre/{genre}` (Get movies by genre)
   - **GET** `/api/movie/fileFormat/{fileFormat}` (Get movies by file format)
   - **GET** `/api/movie/resolution/{resolution}` (Get movies by resolution)
   - **GET** `/api/movie/duration/{minDuration}/{maxDuration}` (Get movies by duration range)
   - **GET** `/api/movie/titleAndDirector/{title}/{director}` (Get movies by title and director)
   - **PUT** `/api/movie/{id}` (Update a movie)
   - **DELETE** `/api/movie/{id}` (Delete a movie)

## Summary

- This controller manages `MovieDisc` entities by offering endpoints for creating, reading, updating, and deleting movies in the system.
- It allows searching for movies based on various filters like director, genre, file format, resolution, and duration.
- The `titleAndDirector` endpoint specifically helps find movies using both the title and director name.
- It responds with appropriate HTTP status codes and messages for success, failure, and not found scenarios.

## Key Changes

- **GET Endpoints**: Added several endpoints to filter movies by `director`, `genre`, `fileFormat`, `resolution`, and `duration`.
- **Search Functionality**: Introduced an endpoint to find movies based on both `title` and `director`.
- **CRUD Support**: Ensured that the controller supports full CRUD operations for the `MovieDisc` entity.
- **PathVariable and RequestParam**: Used `PathVariable` for resource IDs and specific attributes like genre, file format, etc., and `RequestParam` for query parameters (like duration range and title-director combination).
