### PR TITLE
feat: add movie and book unit tests

### DIFF
--- a/library/src/main/java/org/pollub/library/exception/controller/advice/GlobalExceptionHandler.java
+++ b/library/src/main/java/org/pollub/library/exception/controller/advice/GlobalExceptionHandler.java
@@ -31,6 +31,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<String> handleUserNotFoundException(Exception ex) throws JsonProcessingException {
         return errorResponseGenerator.generateResponse(ERROR_MESSAGE, Collections.singletonMap(ERROR, Collections.singletonList(ex.getMessage())), HttpStatus.NOT_FOUND);
     }
+
     @ExceptionHandler({AccessDeniedException.class})
     public ResponseEntity<String> handleForbiddenException(Exception ex) throws JsonProcessingException {
         return errorResponseGenerator.generateResponse(ERROR_MESSAGE, Collections.singletonMap(ERROR, Collections.singletonList(ex.getMessage())), HttpStatus.FORBIDDEN);
@@ -45,6 +46,5 @@ public class GlobalExceptionHandler {
     public ResponseEntity<String> handleAnyException(Exception ex) throws JsonProcessingException {
         return errorResponseGenerator.generateResponse(ERROR_MESSAGE, Collections.singletonMap(ERROR, Collections.singletonList(ex.getMessage())), HttpStatus.BAD_REQUEST);
     }
-
 
 }

--- a/library/src/main/java/org/pollub/library/item/controller/BookController.java
+++ b/library/src/main/java/org/pollub/library/item/controller/BookController.java
@@ -30,6 +30,11 @@ public class BookController {
         return ResponseEntity.ok(bookService.findByAuthor(author));
     }
 
+    @GetMapping("/title/{title}")
+    public ResponseEntity<List<Book>> getBooksByTitle(@PathVariable String title) {
+        return ResponseEntity.ok(bookService.findByTitle(title));
+    }
+
     @GetMapping("/genre/{genre}")
     public ResponseEntity<List<Book>> getBooksByGenre(@PathVariable String genre) {
         return ResponseEntity.ok(bookService.findByGenre(genre));

--- a/library/src/main/java/org/pollub/library/item/controller/MovieController.java
+++ b/library/src/main/java/org/pollub/library/item/controller/MovieController.java
@@ -31,6 +31,11 @@ public class MovieController {
         return ResponseEntity.ok(movieService.findByDirector(director));
     }
 
+    @GetMapping("/title/{title}")
+    public ResponseEntity<List<MovieDisc>> getMoviesByTitle(@PathVariable String title) {
+        return ResponseEntity.ok(movieService.findByTitle(title));
+    }
+
     @GetMapping("/genre/{genre}")
     public ResponseEntity<List<MovieDisc>> getMoviesByGenre(@PathVariable String genre) {
         return ResponseEntity.ok(movieService.findByGenre(genre));

--- a/library/src/main/java/org/pollub/library/item/repository/IBookRepository.java
+++ b/library/src/main/java/org/pollub/library/item/repository/IBookRepository.java
@@ -8,6 +8,7 @@ import java.util.List;
 @Repository
 public interface IBookRepository extends ILibraryItemRepository<Book> {
     List<Book> findByAuthorContainingIgnoreCase(String author);
+    List<Book> findByTitle(String title);
     List<Book> findByGenre(String genre);
     List<Book> findByIsbn(String isbn);
 }

--- a/library/src/main/java/org/pollub/library/item/repository/IMovieRepository.java
+++ b/library/src/main/java/org/pollub/library/item/repository/IMovieRepository.java
@@ -9,9 +9,10 @@ import java.util.Optional;
 @Repository
 public interface IMovieRepository extends ILibraryItemRepository<MovieDisc> {
     List<MovieDisc> findByDirectorContainingIgnoreCase(String director);
+    List<MovieDisc> findByTitle(String title);
     List<MovieDisc> findByGenre(String genre);
     List<MovieDisc> findByFileFormat(String fileFormat);
     List<MovieDisc> findByResolution(String resolution);
     List<MovieDisc> findByDurationBetween(Integer minDuration, Integer maxDuration);
-    Optional<MovieDisc> findByTitleAndAndDirector(String title, String director);
+    Optional<MovieDisc> findByTitleAndDirector(String title, String director);
 }

--- a/library/src/main/java/org/pollub/library/item/service/BookService.java
+++ b/library/src/main/java/org/pollub/library/item/service/BookService.java
@@ -37,6 +37,11 @@ public class BookService implements IBookService {
     }
 
     @Override
+    public List<Book> findByTitle(String title) {
+        return bookRepository.findByTitle(title);
+    }
+
+    @Override
     public List<Book> findByGenre(String genre) {
         return bookRepository.findByGenre(genre);
     }

--- a/library/src/main/java/org/pollub/library/item/service/IBookService.java
+++ b/library/src/main/java/org/pollub/library/item/service/IBookService.java
@@ -9,6 +9,7 @@ public interface IBookService {
     Book createBook(BookCreateDto dto);
     Book findById(Long id);
     List<Book> findByAuthor(String author);
+    List<Book> findByTitle(String title);
     List<Book> findByGenre(String genre);
     Book updateBook(Long id, BookCreateDto dto);
     void deleteBook(Long id);

--- a/library/src/main/java/org/pollub/library/item/service/IMovieService.java
+++ b/library/src/main/java/org/pollub/library/item/service/IMovieService.java
@@ -10,6 +10,7 @@ public interface IMovieService {
     MovieDisc createMovie(MovieCreateDto dto);
     MovieDisc findById(Long id);
     List<MovieDisc> findByDirector(String director);
+    List<MovieDisc> findByTitle(String title);
     List<MovieDisc> findByGenre(String genre);
     List<MovieDisc> findByFileFormat(String fileFormat);
     List<MovieDisc> findByResolution(String resolution);

--- a/library/src/main/java/org/pollub/library/item/service/MovieService.java
+++ b/library/src/main/java/org/pollub/library/item/service/MovieService.java
@@ -37,6 +37,11 @@ public class MovieService implements IMovieService{
     }
 
     @Override
+    public List<MovieDisc> findByTitle(String title) {
+        return movieRepository.findByTitle(title);
+    }
+
+    @Override
     public List<MovieDisc> findByGenre(String genre) {
         return movieRepository.findByGenre(genre);
     }
@@ -58,7 +63,7 @@ public class MovieService implements IMovieService{
 
     @Override
     public Optional<MovieDisc> findByTitleAndDirector(String title, String director) {
-        return movieRepository.findByTitleAndAndDirector(title, director);
+        return movieRepository.findByTitleAndDirector(title, director);
     }
 
     @Override

--- a/library/src/test/java/org/pollub/library/BookServiceTest.java
+++ b/library/src/test/java/org/pollub/library/BookServiceTest.java
@@ -1,0 +1,149 @@
+package org.pollub.library;
+
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.persistence.PersistenceException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.pollub.library.item.model.Book;
+import org.pollub.library.item.model.dto.BookCreateDto;
+import org.pollub.library.item.repository.IBookRepository;
+import org.pollub.library.item.service.BookService;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+class BookServiceTest {
+
+    @Mock
+    private IBookRepository bookRepository;
+
+    @InjectMocks
+    private BookService bookService;
+
+    private BookCreateDto bookCreateDto;
+    private Book book;
+
+    @BeforeEach
+    void setUp() {
+        bookCreateDto = new BookCreateDto();
+        bookCreateDto.setTitle("Test Book");
+        bookCreateDto.setAuthor("Test Author");
+        bookCreateDto.setPageCount(200);
+        bookCreateDto.setPaperType("Paperback");
+        bookCreateDto.setPublisher("Test Publisher");
+        bookCreateDto.setShelfNumber(1);
+        bookCreateDto.setGenre("Fiction");
+        bookCreateDto.setIsbn("123-456-789");
+        bookCreateDto.setDescription("Test Description");
+    }
+
+    @Test
+    @DisplayName("Ensure correct book creation with given BookCreateDto")
+    void givenBookCreateDto_whenCreateBook_thenReturnBook() {
+        book = new Book();
+        when(bookRepository.save(any(Book.class))).thenReturn(book);
+
+        Book createdBook = bookService.createBook(bookCreateDto);
+
+        ArgumentCaptor<Book> bookCaptor = ArgumentCaptor.forClass(Book.class);
+        verify(bookRepository).save(bookCaptor.capture());
+        Book savedBook = bookCaptor.getValue();
+
+        assertNotNull(createdBook);
+        assertEquals("Test Book", savedBook.getTitle());
+        assertEquals("Test Author", savedBook.getAuthor());
+        assertEquals(200, savedBook.getPageCount());
+        assertEquals("Paperback", savedBook.getPaperType());
+        assertEquals("Test Publisher", savedBook.getPublisher());
+        assertEquals(1, savedBook.getShelfNumber());
+        assertEquals("Fiction", savedBook.getGenre());
+        assertEquals("123-456-789", savedBook.getIsbn());
+        assertEquals("Test Description", savedBook.getDescription());
+    }
+
+    @Test
+    @DisplayName("Successfully find book by valid ID")
+    void givenValidBookId_whenFindById_thenReturnBook() {
+        book = new Book();
+        book.setId(1L);
+        book.setTitle("Test Book");
+
+        when(bookRepository.findById(1L)).thenReturn(Optional.of(book));
+
+        Book foundBook = bookService.findById(1L);
+
+        verify(bookRepository).findById(1L);
+        assertNotNull(foundBook);
+        assertEquals(1L, foundBook.getId());
+        assertEquals("Test Book", foundBook.getTitle());
+    }
+
+    @Test
+    @DisplayName("Ensure correct update with given BookCreateDto")
+    void givenBookCreateDto_whenUpdateBook_thenReturnUpdatedBook() {
+        Book bookToUpdate = new Book();
+        bookToUpdate.setId(1L);
+        bookToUpdate.setTitle("Test Book");
+        bookToUpdate.setAuthor("Test Author");
+        bookToUpdate.setPageCount(200);
+        bookToUpdate.setPaperType("Paperback");
+        bookToUpdate.setPublisher("Test Publisher");
+        bookToUpdate.setShelfNumber(1);
+        bookToUpdate.setGenre("Fiction");
+        bookToUpdate.setIsbn("123-456-789");
+        bookToUpdate.setDescription("Test Description");
+
+        when(bookRepository.findById(1L)).thenReturn(Optional.of(bookToUpdate));
+        when(bookRepository.save(any(Book.class))).thenReturn(bookToUpdate);
+
+        bookCreateDto.setTitle("Updated Test Book");
+
+        Book updatedBook = bookService.updateBook(1L, bookCreateDto);
+
+        ArgumentCaptor<Book> updatedBookCaptor = ArgumentCaptor.forClass(Book.class);
+        verify(bookRepository).save(updatedBookCaptor.capture());
+        Book updatedSavedBook = updatedBookCaptor.getValue();
+
+        assertNotNull(updatedBook);
+        assertEquals("Updated Test Book", updatedSavedBook.getTitle());
+        assertEquals("Test Author", updatedSavedBook.getAuthor());
+        assertEquals(200, updatedSavedBook.getPageCount());
+        assertEquals("Paperback", updatedSavedBook.getPaperType());
+        assertEquals("Test Publisher", updatedSavedBook.getPublisher());
+        assertEquals(1, updatedSavedBook.getShelfNumber());
+        assertEquals("Fiction", updatedSavedBook.getGenre());
+        assertEquals("123-456-789", updatedSavedBook.getIsbn());
+        assertEquals("Test Description", updatedSavedBook.getDescription());
+    }
+
+
+    @Test
+    @DisplayName("Throw EntityNotFoundException when deleting non-existing book")
+    void givenNonExistingBook_whenDeleteBook_thenThrowEntityNotFoundException() {
+        when(bookRepository.existsById(1L)).thenReturn(false);
+
+        assertThrows(EntityNotFoundException.class, () -> bookService.deleteBook(1L));
+    }
+
+    @Test
+    @DisplayName("Successfully delete existing book with given ID")
+    void givenExistingBook_whenDeleteBook_thenDeleteBook() {
+        when(bookRepository.existsById(1L)).thenReturn(true);
+
+        bookService.deleteBook(1L);
+
+        verify(bookRepository).deleteById(1L);
+    }
+
+
+}

--- a/library/src/test/java/org/pollub/library/MovieServiceTest.java
+++ b/library/src/test/java/org/pollub/library/MovieServiceTest.java
@@ -1,0 +1,132 @@
+package org.pollub.library;
+
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.pollub.library.item.model.MovieDisc;
+import org.pollub.library.item.model.dto.MovieCreateDto;
+import org.pollub.library.item.repository.IMovieRepository;
+import org.pollub.library.item.service.MovieService;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+class MovieServiceTest {
+
+    @Mock
+    private IMovieRepository movieRepository;
+
+    @InjectMocks
+    private MovieService movieService;
+
+    private MovieCreateDto movieCreateDto;
+
+    @BeforeEach
+    void setUp() {
+        movieCreateDto = new MovieCreateDto();
+        movieCreateDto.setTitle("Test Movie");
+        movieCreateDto.setDirector("Test Director");
+        movieCreateDto.setResolution("1080p");
+        movieCreateDto.setDuration(120);
+        movieCreateDto.setFileFormat("MP4");
+        movieCreateDto.setGenre("Action");
+        movieCreateDto.setShelfNumber(1);
+        movieCreateDto.setDigitalRights("Test DigitalRights");
+    }
+
+    @Test
+    @DisplayName("Ensure correct movie creation with given MovieCreateDto")
+    void givenMovieCreateDto_whenCreateMovie_thenReturnMovie() {
+        MovieDisc movie = new MovieDisc();
+        when(movieRepository.save(any(MovieDisc.class))).thenReturn(movie);
+
+        MovieDisc createdMovie = movieService.createMovie(movieCreateDto);
+
+        ArgumentCaptor<MovieDisc> movieCaptor = ArgumentCaptor.forClass(MovieDisc.class);
+        verify(movieRepository).save(movieCaptor.capture());
+        MovieDisc savedMovie = movieCaptor.getValue();
+
+        assertNotNull(createdMovie);
+        assertEquals("Test Movie", savedMovie.getTitle());
+        assertEquals("Test Director", savedMovie.getDirector());
+        assertEquals("1080p", savedMovie.getResolution());
+        assertEquals(120, savedMovie.getDuration());
+        assertEquals("MP4", savedMovie.getFileFormat());
+        assertEquals("Action", savedMovie.getGenre());
+        assertEquals(1, savedMovie.getShelfNumber());
+        assertEquals("Test DigitalRights", savedMovie.getDigitalRights());
+    }
+
+    @Test
+    @DisplayName("Throw EntityNotFoundException for invalid movie ID")
+    void givenInvalidMovieId_whenFindById_thenThrowEntityNotFoundException() {
+        when(movieRepository.findById(1L)).thenReturn(Optional.empty());
+        assertThrows(EntityNotFoundException.class, () -> movieService.findById(1L));
+    }
+
+    @Test
+    @DisplayName("Ensure correct update with given MovieCreateDto")
+    void givenMovieCreateDto_whenUpdateMovie_thenReturnUpdatedMovie() {
+        MovieDisc movieToUpdate = new MovieDisc();
+        movieToUpdate.setId(1L);
+        movieToUpdate.setTitle("Test Movie");
+        movieToUpdate.setDirector("Test Director");
+        movieToUpdate.setResolution("1080p");
+        movieToUpdate.setDuration(120);
+        movieToUpdate.setFileFormat("MP4");
+        movieToUpdate.setGenre("Action");
+        movieToUpdate.setShelfNumber(1);
+        movieToUpdate.setDigitalRights("Test DigitalRights");
+
+        when(movieRepository.findById(1L)).thenReturn(Optional.of(movieToUpdate));
+        when(movieRepository.save(any(MovieDisc.class))).thenReturn(movieToUpdate);
+
+        movieCreateDto.setTitle("Updated Test Movie");
+
+        MovieDisc updatedMovie = movieService.updateMovie(1L, movieCreateDto);
+
+        ArgumentCaptor<MovieDisc> updatedMovieCaptor = ArgumentCaptor.forClass(MovieDisc.class);
+        verify(movieRepository).save(updatedMovieCaptor.capture());
+        MovieDisc updatedSavedMovie = updatedMovieCaptor.getValue();
+
+        assertNotNull(updatedMovie);
+        assertEquals("Updated Test Movie", updatedSavedMovie.getTitle());
+        assertEquals("Test Director", updatedSavedMovie.getDirector());
+        assertEquals("1080p", updatedSavedMovie.getResolution());
+        assertEquals(120, updatedSavedMovie.getDuration());
+        assertEquals("MP4", updatedSavedMovie.getFileFormat());
+        assertEquals("Action", updatedSavedMovie.getGenre());
+        assertEquals(1, updatedSavedMovie.getShelfNumber());
+        assertEquals("Test DigitalRights", updatedSavedMovie.getDigitalRights());
+    }
+
+
+    @Test
+    @DisplayName("Throw EntityNotFoundException for non-existing movie in deleteMovie")
+    void givenNonExistingMovie_whenDeleteMovie_thenThrowEntityNotFoundException() {
+        when(movieRepository.existsById(1L)).thenReturn(false);
+
+        assertThrows(EntityNotFoundException.class, () -> movieService.deleteMovie(1L));
+    }
+
+    @Test
+    @DisplayName("Successfully delete existing movie with given ID")
+    void givenExistingMovie_whenDeleteMovie_thenDeleteMovie() {
+        when(movieRepository.existsById(1L)).thenReturn(true);
+
+        movieService.deleteMovie(1L);
+
+        verify(movieRepository).deleteById(1L);
+    }
+
+
+}


### PR DESCRIPTION
# Project Updates: Movie and Book Unit Tests

## Overview
This update includes the addition of new endpoints to the `MovieController` and `BookController` for retrieving movies and books by specific criteria. Additionally, unit tests have been implemented for both `BookService` and `MovieService` to ensure correct functionality.

---

## New Endpoints
   - **BookController**:
     - `GET /api/book/{title}` (Get book by Ttitle).

   - **MovieController**:
     - `GET /api/movie/{title}` (Get movie by Ttitle).

## Unit Tests

### BookService Tests
- **Book Creation Test**: Ensures that a book can be created successfully with a given `BookCreateDto`.
- **Find Book by ID Test**: Validates that a book can be retrieved by a valid ID.
- **Update Book Test**: Verifies that an existing book can be updated with new information.
- **Delete Book Tests**:
  - Throws `EntityNotFoundException` when trying to delete a non-existing book.
  - Successfully deletes an existing book.

### MovieService Tests
- **Movie Creation Test**: Ensures that a movie can be created successfully with a given `MovieCreateDto`.
- **Find Movie by ID Test**: Validates that a movie can be retrieved by a valid ID. Throws `EntityNotFoundException` for an invalid ID.
- **Update Movie Test**: Verifies that an existing movie can be updated with new information.
- **Delete Movie Tests**:
  - Throws `EntityNotFoundException` when trying to delete a non-existing movie.
  - Successfully deletes an existing movie.

## Future Plans
More tests will be added in the future